### PR TITLE
Add iOS PWA installation support with modal instructions

### DIFF
--- a/custom-theme.css
+++ b/custom-theme.css
@@ -340,15 +340,16 @@
 .install-button {
   background-color: white;
   color: var(--comune-green);
-  border: 2px solid var(--comune-green);
-  border-radius: 6px;
-  padding: 8px 16px;
-  font-weight: bold;
-  font-size: 0.9rem;
+  border: 1px solid var(--comune-green);
+  border-radius: 4px;
+  padding: 2px 8px;
+  font-weight: 600;
+  font-size: 0.75rem;
   transition: all 0.3s ease;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 3px;
+  white-space: nowrap;
 }
 
 .install-button:hover {
@@ -364,9 +365,25 @@
 /* Responsive Adjustments */
 @media (max-width: 768px) {
   .it-header-wrapper .it-header-slim-wrapper-content {
-    flex-direction: column;
-    gap: 10px;
-    text-align: center;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .it-header-wrapper .header-slim-left {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .it-header-wrapper .it-brand-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .it-header-wrapper .header-slim-right {
+    flex: 0 0 auto;
   }
   
   .badge-waste {
@@ -376,8 +393,8 @@
   }
   
   .install-button {
-    font-size: 0.8rem;
-    padding: 6px 12px;
+    font-size: 0.7rem;
+    padding: 2px 6px;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                                 <div class="d-flex align-items-center gap-3">
                                     <button id="install-button" class="btn btn-outline-light btn-sm install-button"
                                         style="display: none;">
-                                        <svg class="icon icon-sm me-1 dark">
+                                        <svg class="icon me-1 dark" style="width: 12px; height: 12px;">
                                             <use href="bootstrap-italia/svg/sprites.svg#it-plus"></use>
                                         </svg>
                                         Installa

--- a/index.html
+++ b/index.html
@@ -269,6 +269,35 @@
         </div>
     </div>
 
+    <!-- iOS Install Instructions Modal -->
+    <div class="modal fade" id="ios-install-modal" tabindex="-1" aria-labelledby="iosInstallModalLabel"
+        aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="iosInstallModalLabel">Installa l'app</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Chiudi"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Per installare questa app sul tuo dispositivo iOS:</p>
+                    <ol class="mb-0">
+                        <li>Tocca l'icona <strong>Condividi</strong>
+                            <svg class="icon icon-sm align-middle">
+                                <use href="bootstrap-italia/svg/sprites.svg#it-share"></use>
+                            </svg>
+                            nella barra di Safari.
+                        </li>
+                        <li>Scorri e seleziona <strong>"Aggiungi a Home"</strong>.</li>
+                        <li>Tocca <strong>"Aggiungi"</strong> in alto a destra.</li>
+                    </ol>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Chiudi</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Bootstrap Italia JavaScript -->
     <script src="bootstrap-italia/js/bootstrap-italia.bundle.min.js"></script>
 
@@ -1114,44 +1143,46 @@
         // PWA Installation functionality
         let deferredPrompt;
         const installButton = document.getElementById('install-button');
+        const isStandalone = window.navigator.standalone === true
+            || window.matchMedia('(display-mode: standalone)').matches;
+        const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent)
+            || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
 
-        // Listen for the beforeinstallprompt event
+        // Register service worker so Chromium browsers consider the page installable.
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('sw.js').catch(() => { /* ignore */ });
+            });
+        }
+
         window.addEventListener('beforeinstallprompt', (e) => {
-            // Prevent the mini-infobar from appearing on mobile
             e.preventDefault();
-            // Save the event so it can be triggered later
+            if (isStandalone) return;
             deferredPrompt = e;
-            // Show the install button
             installButton.style.display = 'flex';
         });
 
-        // Handle install button click
         installButton.addEventListener('click', async () => {
             if (deferredPrompt) {
-                // Show the install prompt
                 deferredPrompt.prompt();
-                // Wait for the user to respond to the prompt
-                const { outcome } = await deferredPrompt.userChoice;
-                // Clear the deferredPrompt for future use
+                await deferredPrompt.userChoice;
                 deferredPrompt = null;
-                // Hide the install button
                 installButton.style.display = 'none';
+            } else if (isIos) {
+                bootstrap.Modal.getOrCreateInstance(document.getElementById('ios-install-modal')).show();
             }
         });
 
-        // Listen for the app to be installed
-        window.addEventListener('appinstalled', (e) => {
-            // Hide the install button
+        window.addEventListener('appinstalled', () => {
             installButton.style.display = 'none';
-            // Clear the deferredPrompt
             deferredPrompt = null;
         });
 
-        // Check if app is already installed (for iOS and other platforms)
         window.addEventListener('DOMContentLoaded', () => {
-            // For iOS Safari, check if running in standalone mode
-            if (window.navigator.standalone || window.matchMedia('(display-mode: standalone)').matches) {
+            if (isStandalone) {
                 installButton.style.display = 'none';
+            } else if (isIos) {
+                installButton.style.display = 'flex';
             }
         });
     </script>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,3 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+self.addEventListener('fetch', () => { /* required for PWA install criteria */ });


### PR DESCRIPTION
## Summary
Enhanced PWA installation functionality to support iOS devices with a dedicated installation instructions modal, while improving the existing Chromium-based installation flow.

## Key Changes
- **Added iOS Install Modal**: New Bootstrap modal (`ios-install-modal`) with step-by-step instructions for installing the app on iOS devices via Safari's "Add to Home Screen" feature
- **Service Worker Registration**: Implemented basic service worker (`sw.js`) to meet PWA installation criteria for Chromium browsers
- **Platform Detection**: Added logic to detect iOS devices and standalone mode to conditionally show appropriate installation UI
- **Improved Install Flow**: 
  - Refactored PWA installation event handlers with cleaner code and removed unnecessary comments
  - Show iOS modal when install button is clicked on iOS devices without native install prompt support
  - Automatically hide install button when app is already in standalone mode
  - Show install button on iOS devices when not in standalone mode to trigger the modal

## Implementation Details
- Detects iOS via user agent and platform checks
- Detects standalone mode via `window.navigator.standalone` and CSS media query `(display-mode: standalone)`
- Service worker includes minimal required handlers for fetch events to satisfy PWA installation criteria
- Modal displays Italian localized instructions for iOS users
- Install button behavior now adapts based on platform capabilities and app installation state

https://claude.ai/code/session_01XMkrz7Fr8Ymi94dc8BCgyp